### PR TITLE
Add unnamed implementation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,7 +40,7 @@ Each digit group is run for 100000 times. The minimum time duration is measured 
 3. Run `premake.bat` or `premake.sh` in `itoa-benchmark/build`
 4. On Windows, build the solution at `itoa-benchmark/build/vs2008/` or `/vs2010/`.
 5. On other platforms, run GNU `make config=release32` (or `release64`) at `itoa-benchmark/build/gmake/`
-6. On success, run the `itoa` executable is generated at `itoa-benchmark/`
+6. On success, run the `itoa` executable is generated at `itoa-benchmark/bin/`
 7. The results in CSV format will be written to `itoa-benchmark/result`.
 8. Run GNU `make` in `itoa-benchmark/result` to generate results in HTML.
 
@@ -85,6 +85,7 @@ to_string     | `std::to_string()` in C++11 standard library.
 sprintf       | `sprintf()` in C standard library
 vc            | Visual C++'s `_itoa()`, `_i64toa()`, `_ui64toa()`
 naive         | Compute division/modulo of 10 for each digit, store digits in temp array and copy to buffer in reverse order.
+unnamed       | Compute division/modulo of 10 for each digit, store directly in buffer
 count         | Count number of decimal digits first, using technique from [1].
 lut           | Uses lookup table (LUT) of digit pairs for division/modulo of 100. Mentioned in [2]
 countlut      | Combines count and lut.

--- a/src/unnamed.cpp
+++ b/src/unnamed.cpp
@@ -1,0 +1,118 @@
+#include <stdint.h>
+#include "test.h"
+
+void u32toa_unnamed(uint32_t value, char* buffer) {
+    if (1000000000UL <= value) { *buffer++ = (char)((value / 1000000000UL) % 10 + '0'); }
+    if ( 100000000UL <= value) { *buffer++ = (char)((value /  100000000UL) % 10 + '0'); }
+    if (  10000000UL <= value) { *buffer++ = (char)((value /   10000000UL) % 10 + '0'); }
+    if (   1000000UL <= value) { *buffer++ = (char)((value /    1000000UL) % 10 + '0'); }
+    if (    100000UL <= value) { *buffer++ = (char)((value /     100000UL) % 10 + '0'); }
+    if (     10000UL <= value) { *buffer++ = (char)((value /      10000UL) % 10 + '0'); }
+    if (      1000UL <= value) { *buffer++ = (char)((value /       1000UL) % 10 + '0'); }
+    if (       100UL <= value) { *buffer++ = (char)((value /        100UL) % 10 + '0'); }
+    if (        10UL <= value) { *buffer++ = (char)((value /         10UL) % 10 + '0'); }
+
+    *buffer++ = (char)(value % 10 + '0');
+    *buffer = '\0';
+}
+
+void i32toa_unnamed(int32_t value, char* buffer) {
+    if (value == INT32_MIN) {
+        memcpy(buffer, "-2147483648\0", 12);
+        return;
+    }
+
+    if (value < 0) {
+        *buffer++ = '-';
+        value = -value;
+    }
+
+    if (1000000000L <= value) { *buffer++ = (char)((value / 1000000000L) % 10 + '0'); }
+    if ( 100000000L <= value) { *buffer++ = (char)((value /  100000000L) % 10 + '0'); }
+    if (  10000000L <= value) { *buffer++ = (char)((value /   10000000L) % 10 + '0'); }
+    if (   1000000L <= value) { *buffer++ = (char)((value /    1000000L) % 10 + '0'); }
+    if (    100000L <= value) { *buffer++ = (char)((value /     100000L) % 10 + '0'); }
+    if (     10000L <= value) { *buffer++ = (char)((value /      10000L) % 10 + '0'); }
+    if (      1000L <= value) { *buffer++ = (char)((value /       1000L) % 10 + '0'); }
+    if (       100L <= value) { *buffer++ = (char)((value /        100L) % 10 + '0'); }
+    if (        10L <= value) { *buffer++ = (char)((value /         10L) % 10 + '0'); }
+
+    *buffer++ = (char)(value % 10 + '0');
+    *buffer = '\0';
+}
+
+void u64toa_unnamed(uint64_t value, char* buffer) {
+  if ((value >> 32) == 0) {
+      u32toa_unnamed(static_cast<uint32_t>(value), buffer);
+      return;
+  }
+
+  if (10000000000000000000ULL <= value) { *buffer++ = (char)((value / 10000000000000000000ULL) % 10 + '0'); }
+  if ( 1000000000000000000ULL <= value) { *buffer++ = (char)((value /  1000000000000000000ULL) % 10 + '0'); }
+  if (  100000000000000000ULL <= value) { *buffer++ = (char)((value /   100000000000000000ULL) % 10 + '0'); }
+  if (   10000000000000000ULL <= value) { *buffer++ = (char)((value /    10000000000000000ULL) % 10 + '0'); }
+  if (    1000000000000000ULL <= value) { *buffer++ = (char)((value /     1000000000000000ULL) % 10 + '0'); }
+  if (     100000000000000ULL <= value) { *buffer++ = (char)((value /      100000000000000ULL) % 10 + '0'); }
+  if (      10000000000000ULL <= value) { *buffer++ = (char)((value /       10000000000000ULL) % 10 + '0'); }
+  if (       1000000000000ULL <= value) { *buffer++ = (char)((value /        1000000000000ULL) % 10 + '0'); }
+  if (        100000000000ULL <= value) { *buffer++ = (char)((value /         100000000000ULL) % 10 + '0'); }
+  if (         10000000000ULL <= value) { *buffer++ = (char)((value /          10000000000ULL) % 10 + '0'); }
+  if (          1000000000ULL <= value) { *buffer++ = (char)((value /           1000000000ULL) % 10 + '0'); }
+  if (           100000000ULL <= value) { *buffer++ = (char)((value /            100000000ULL) % 10 + '0'); }
+  if (            10000000ULL <= value) { *buffer++ = (char)((value /             10000000ULL) % 10 + '0'); }
+  if (             1000000ULL <= value) { *buffer++ = (char)((value /              1000000ULL) % 10 + '0'); }
+  if (              100000ULL <= value) { *buffer++ = (char)((value /               100000ULL) % 10 + '0'); }
+  if (               10000ULL <= value) { *buffer++ = (char)((value /                10000ULL) % 10 + '0'); }
+  if (                1000ULL <= value) { *buffer++ = (char)((value /                 1000ULL) % 10 + '0'); }
+  if (                 100ULL <= value) { *buffer++ = (char)((value /                  100ULL) % 10 + '0'); }
+  if (                  10ULL <= value) { *buffer++ = (char)((value /                   10ULL) % 10 + '0'); }
+
+  *buffer++ = (char)(value % 10 + '0');
+  *buffer = '\0';
+}
+
+void i64toa_unnamed(int64_t value, char* buffer) {
+    if (value == INT64_MIN) {
+        memcpy(buffer, "-9223372036854775808\0", 21);
+        return;
+    }
+
+    if (value >= 0 && (value >> 32) == 0) {
+        u32toa_unnamed(static_cast<uint32_t>(value), buffer);
+        return;
+    }
+
+    if (value < 0) {
+        *buffer++ = '-';
+        value = -value;
+
+        if ((value >> 32) == 0) {
+            u32toa_unnamed(static_cast<uint32_t>(value), buffer);
+            return;
+        }
+    }
+
+    if (1000000000000000000LL <= value) { *buffer++ = (char)((value / 1000000000000000000LL) % 10 + '0'); }
+    if ( 100000000000000000LL <= value) { *buffer++ = (char)((value /  100000000000000000LL) % 10 + '0'); }
+    if (  10000000000000000LL <= value) { *buffer++ = (char)((value /   10000000000000000LL) % 10 + '0'); }
+    if (   1000000000000000LL <= value) { *buffer++ = (char)((value /    1000000000000000LL) % 10 + '0'); }
+    if (    100000000000000LL <= value) { *buffer++ = (char)((value /     100000000000000LL) % 10 + '0'); }
+    if (     10000000000000LL <= value) { *buffer++ = (char)((value /      10000000000000LL) % 10 + '0'); }
+    if (      1000000000000LL <= value) { *buffer++ = (char)((value /       1000000000000LL) % 10 + '0'); }
+    if (       100000000000LL <= value) { *buffer++ = (char)((value /        100000000000LL) % 10 + '0'); }
+    if (        10000000000LL <= value) { *buffer++ = (char)((value /         10000000000LL) % 10 + '0'); }
+    if (         1000000000LL <= value) { *buffer++ = (char)((value /          1000000000LL) % 10 + '0'); }
+    if (          100000000LL <= value) { *buffer++ = (char)((value /           100000000LL) % 10 + '0'); }
+    if (           10000000LL <= value) { *buffer++ = (char)((value /            10000000LL) % 10 + '0'); }
+    if (            1000000LL <= value) { *buffer++ = (char)((value /             1000000LL) % 10 + '0'); }
+    if (             100000LL <= value) { *buffer++ = (char)((value /              100000LL) % 10 + '0'); }
+    if (              10000LL <= value) { *buffer++ = (char)((value /               10000LL) % 10 + '0'); }
+    if (               1000LL <= value) { *buffer++ = (char)((value /                1000LL) % 10 + '0'); }
+    if (                100LL <= value) { *buffer++ = (char)((value /                 100LL) % 10 + '0'); }
+    if (                 10LL <= value) { *buffer++ = (char)((value /                  10LL) % 10 + '0'); }
+
+    *buffer++ = (char)(value % 10 + '0');
+    *buffer = '\0';
+}
+
+REGISTER_TEST(unnamed);


### PR DESCRIPTION
Yet another implementation for itoa-benchmark.
The added variant is much like the naive variant, however, it stores the digits in the result buffer directly and does not need a temporary buffer. It will perform division and modulo operations for each digit, so it's quite expensive. Still wanted to add this for fun & education and to see how it compares to the other implementations. On my box it's better than *naive* and outperforms a few other implementations in some tests, but it's never even near the top.