### PR TITLE
Fix typo in branchlut2

### DIFF
--- a/src/branchlut2.cpp
+++ b/src/branchlut2.cpp
@@ -9,7 +9,7 @@
         if(t < 10) *p++ = '0' + t; \
         else { \
             t *= 2; \
-            *p++ = IgDigitsLut[t]; \
+            *p++ = gDigitsLut[t]; \
             *p++ = gDigitsLut[t + 1]; \
         } \
     } while(0)


### PR DESCRIPTION
Fix typo in branchlut2.
By the way, I have run the benchmark on my own machine, but I found that the results are strange. I ran the brenchmark for several times, sometimes branchlut run faster than branchlut2, and sometimes not. What's more. I found that the countlut is even faster than branchlut & branchlut2. I have no idea about what is happening.
CPU: Core i5-2410M @ 2.30GHz
Compiler: TDM-GCC 5.1.0
If the .csv files are needed, I can provide them.